### PR TITLE
Removed code to ensure that fireBeginLoadingLogReason is run on persiste...

### DIFF
--- a/UbiquityStoreManager/UbiquityStoreManager.m
+++ b/UbiquityStoreManager/UbiquityStoreManager.m
@@ -913,11 +913,6 @@ typedef NS_ENUM(NSUInteger, USMEnabledStore) {
 
 - (void)fireBeginLoadingLogReason:(NSString *)reason {
 
-    if ([NSOperationQueue currentQueue] != self.persistentStorageQueue) {
-        [self enqueue:^{ [self fireBeginLoadingLogReason:reason]; } waitUntilFinished:YES lock:NO];
-        return;
-    }
-
     [self log:@"%@.  Notifying application to reset its UI.", reason];
     if ([self.delegate respondsToSelector:@selector(ubiquityStoreManager:willLoadStoreIsCloud:)])
         [self.delegate ubiquityStoreManager:self willLoadStoreIsCloud:self.cloudEnabled];

--- a/UbiquityStoreManagerExample.xcodeproj/project.xcworkspace/xcshareddata/UbiquityStoreManagerExample.xccheckout
+++ b/UbiquityStoreManagerExample.xcodeproj/project.xcworkspace/xcshareddata/UbiquityStoreManagerExample.xccheckout
@@ -10,29 +10,29 @@
 	<string>UbiquityStoreManagerExample</string>
 	<key>IDESourceControlProjectOriginsDictionary</key>
 	<dict>
-		<key>5263993D-5FE8-464F-B66E-B0F7C2DFF410</key>
-		<string>ssh://github.com/lhunath/UbiquityStoreManager.git</string>
+		<key>E47DEC29CB0D0FDE3560EF46E1808FA1C723D657</key>
+		<string>https://github.com/pascalfribi/UbiquityStoreManager.git</string>
 	</dict>
 	<key>IDESourceControlProjectPath</key>
-	<string>UbiquityStoreManagerExample.xcodeproj/project.xcworkspace</string>
+	<string>UbiquityStoreManagerExample.xcodeproj</string>
 	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
 	<dict>
-		<key>5263993D-5FE8-464F-B66E-B0F7C2DFF410</key>
+		<key>E47DEC29CB0D0FDE3560EF46E1808FA1C723D657</key>
 		<string>../..</string>
 	</dict>
 	<key>IDESourceControlProjectURL</key>
-	<string>ssh://github.com/lhunath/UbiquityStoreManager.git</string>
+	<string>https://github.com/pascalfribi/UbiquityStoreManager.git</string>
 	<key>IDESourceControlProjectVersion</key>
-	<integer>110</integer>
+	<integer>111</integer>
 	<key>IDESourceControlProjectWCCIdentifier</key>
-	<string>5263993D-5FE8-464F-B66E-B0F7C2DFF410</string>
+	<string>E47DEC29CB0D0FDE3560EF46E1808FA1C723D657</string>
 	<key>IDESourceControlProjectWCConfigurations</key>
 	<array>
 		<dict>
 			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
 			<string>public.vcs.git</string>
 			<key>IDESourceControlWCCIdentifierKey</key>
-			<string>5263993D-5FE8-464F-B66E-B0F7C2DFF410</string>
+			<string>E47DEC29CB0D0FDE3560EF46E1808FA1C723D657</string>
 			<key>IDESourceControlWCCName</key>
 			<string>UbiquityStoreManager</string>
 		</dict>


### PR DESCRIPTION
...nt queue. This has lead to a deadlock on 10.10 when iCloud is activated and code in willLoadStore:isICloud delegate is using [managedObjectContext performBlockAndWait]. It is not critical that this code is run on persistenStorageQueue as most activites are in delegate callback anyway.
